### PR TITLE
task-419, replaced httplib2 with requests

### DIFF
--- a/mpds_client/errors.py
+++ b/mpds_client/errors.py
@@ -14,6 +14,7 @@ class APIError(Exception):
         429: "Too Many Requests (Rate Limiting)",
         500: "Internal Server Error",
         501: "Not Implemented",
+        502: "Bad Gateway",
         503: "Service Unavailable",
     }
 

--- a/mpds_client/retrieve_MPDS.py
+++ b/mpds_client/retrieve_MPDS.py
@@ -5,7 +5,7 @@ import math
 import warnings
 from urllib.parse import urlencode
 
-import httplib2
+import requests
 import ujson as json
 import polars as pl
 from numpy import array_split
@@ -127,8 +127,6 @@ class MPDSDataRetrieval(object):
         """
         self.api_key = api_key if api_key else os.environ["MPDS_KEY"]
 
-        self.network = httplib2.Http()
-
         self.endpoint = endpoint or self.endpoint
         self.dtype = dtype or MPDSDataTypes.PEER_REVIEWED
         self.verbose = verbose if verbose is not None else self.verbose
@@ -154,16 +152,14 @@ class MPDSDataRetrieval(object):
         if self.debug:
             print('curl -XGET -HKey:%s "%s"' % (self.api_key, uri))
 
-        response, content = self.network.request(
-            uri=uri, method="GET", headers={"Key": self.api_key}
-        )
+        response = requests.get(uri, headers={"Key": self.api_key})
 
-        if response.status != 200:
-            return {"error": content, "code": response.status}
+        if response.status_code != 200:
+            return {"error": response.text, "code": response.status_code}
 
         try:
-            content = json.loads(content)
-        except:
+            content = json.loads(response.text)
+        except (ValueError, json.JSONDecodeError):
             return {"error": "Unreadable data obtained"}
 
         if content.get("error"):

--- a/mpds_client/retrieve_MPDS.py
+++ b/mpds_client/retrieve_MPDS.py
@@ -159,7 +159,7 @@ class MPDSDataRetrieval(object):
 
         try:
             content = json.loads(response.text)
-        except (ValueError, json.JSONDecodeError):
+        except ValueError:
             return {"error": "Unreadable data obtained"}
 
         if content.get("error"):

--- a/mpds_client/retrieve_MPDS.py
+++ b/mpds_client/retrieve_MPDS.py
@@ -11,7 +11,7 @@ import polars as pl
 from numpy import array_split
 import jmespath
 
-from errors import APIError
+from .errors import APIError
 
 use_pmg, use_ase = False, False
 

--- a/mpds_client/test_export_MPDS.py
+++ b/mpds_client/test_export_MPDS.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import polars as pl
-from export_MPDS import MPDSExport
+from .export_MPDS import MPDSExport
 
 
 class TestMPDSExport(unittest.TestCase):

--- a/mpds_client/test_retrieve_MPDS.py
+++ b/mpds_client/test_retrieve_MPDS.py
@@ -3,12 +3,11 @@ import unittest
 
 import polars as pl
 
-import httplib2
-import ujson as json
+import requests
 from jsonschema import validate, Draft4Validator
 from jsonschema.exceptions import ValidationError
 
-from retrieve_MPDS import MPDSDataRetrieval
+from .retrieve_MPDS import MPDSDataRetrieval
 import logging
 
 
@@ -17,13 +16,10 @@ class MPDSDataRetrievalTest(unittest.TestCase):
     def setUpClass(cls):
         # warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")
 
-        network = httplib2.Http()
-        response, content = network.request(
-            "https://developer.mpds.io/mpds.schema.json"
-        )
-        assert response.status == 200
+        response = requests.get("https://developer.mpds.io/mpds.schema.json")
+        assert response.status_code == 200
 
-        cls.schema = json.loads(content)
+        cls.schema = response.json()
         Draft4Validator.check_schema(cls.schema)
 
     def test_valid_answer(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 install_requires = [
-    'httplib2',
+    'requests',
     'ujson',
     'numpy',
     'polars',


### PR DESCRIPTION
Added 502 bad gateway error handling
Replaced httplib2 with requests
**Reasons**
1. No default timeout — it would hang forever on slow API responses
2. Broken connection reuse — it couldn't recover from dropped connections mid-sequence